### PR TITLE
issue-137: Fix issue S3 downloads index.html instead of serving it

### DIFF
--- a/tutorial/s3-static-website/main.tf
+++ b/tutorial/s3-static-website/main.tf
@@ -63,6 +63,7 @@ resource "aws_s3_object" "index_file_upload" {
   bucket      = "${aws_s3_bucket.tungbq_s3_website.bucket}"
   key         = "index.html"
   source      = local.index_html_source
+  content_type = "text/html"
 }
 
 
@@ -74,4 +75,5 @@ resource "aws_s3_object" "err_file_upload" {
   bucket      = "${aws_s3_bucket.tungbq_s3_website.bucket}"
   key         = "error.html"
   source      = local.error_html_source
+  content_type = "text/html"
 }


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #137 
Using `content_type = "text/html"` option while uploading