### PR TITLE
Feat[#228]:Do NOT run greeting.yml workflow if the PR author is me (tungbq)

### DIFF
--- a/.github/workflows/greetings.yml
+++ b/.github/workflows/greetings.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   greeting:
     runs-on: ubuntu-latest
-    if: ${{ github.actor != 'all-contributors[bot]' }}
+    if: ${{ github.actor != 'all-contributors[bot]' && github.event.pull_request.user.login != 'tungbq' }}
     permissions:
       issues: write
       pull-requests: write


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #228
> *Be noted that 228 is the issue ID*

## What is the purpose of the change
This pull request updates the `greetings.yml` workflow to prevent it from running if the PR author is `tungbq`. This will help to save CI resources.

**Changes:**

* Added the `&& github.event.pull_request.user.login != 'tungbq'` condition to the `if` statement in the `greeting` job. This condition will check if the PR author is not `tungbq`, and if it is not, then the workflow will run.


*(E.g.: This pull request improves documentation of area A by adding ....)*
