### PR TITLE
fix: correct broken Terraform guide link in local-exec single-command

### DIFF
--- a/getting-started/local-exec/single-command/README.md
+++ b/getting-started/local-exec/single-command/README.md
@@ -1,1 +1,1 @@
-### To deploy Lab for this demo - check the [terraform guideline](../../TERRAFORM-GUIDE.md)
+### To deploy Lab for this demo - check the [terraform guideline](../../../TERRAFORM-GUIDE.md)


### PR DESCRIPTION
## Summary\n- fix relative path for the Terraform guide link in:\n  - `getting-started/local-exec/single-command/README.md`\n- update from `../../TERRAFORM-GUIDE.md` to `../../../TERRAFORM-GUIDE.md`\n\n## Validation\n- resolved path now points to existing `TERRAFORM-GUIDE.md`\n\nFixes #289